### PR TITLE
fix(script): --ignore flag was not working properly for all scenarios

### DIFF
--- a/script.js
+++ b/script.js
@@ -10,6 +10,7 @@ export async function script(octokit, repository, { unwatch, ignore }) {
 		throw new Error("Use either --unwatch or --ignore, not both")
 	}
 	
+	const subscribe = !ignore && !unwatch
 	const method = unwatch ? "DELETE" : "PUT";
 	const id = repository.id;
 	const owner = repository.owner.login;
@@ -24,16 +25,17 @@ export async function script(octokit, repository, { unwatch, ignore }) {
 			({ data: { subscribed, ignored } }) => ({ subscribed, ignored }),
 			() => ({ subscribed: false, ignored: false })
 	);
+	const unsubscribed = !subscribed && !ignored
 	
 	octokit.log.debug(
 		{
 			change: 0,
 		},
 		"subscribed: %s, ignored: %s, unwatch: %s, ignore: %s",
-		subscribed, ignored, unwatch, ignore
+		subscribed, ignored, !!unwatch, !!ignore
 	);
 	
-	if ((unwatch && !subscribed) || (!unwatch && subscribed) || (ignored && ignore)) {
+	if ((subscribed && subscribe) || (ignored && ignore) || (unsubscribed && unwatch)) {
 		octokit.log.debug(
 		{
 			change: 0,


### PR DESCRIPTION
## 📝 Summary
<!--- Provide a general summary of your changes, and if you feel that the commit comments are not descriptive enough, give more detail of your changes -->
- `--ignore` flag is being applied properly when there is an existing subscription for a repository

## ⛱ Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When running `--ignore` flag for already subscribed repositories was entering in a condition where it was not doing anything.

These are the scenarios where the command should skip:

|                   |     isSubscribed    |  isIgnored  |  isUnsubscribed  |
|-----------|:-----------------:|-----------:|-----------------:|
| subscribe |  🛑                         | ✅               | ✅                          |
| unwatch   |  ✅                         | ✅               | 🛑                          |
| ignore       | ✅                         | 🛑               | ✅                           |

Fix #3 